### PR TITLE
DbContext disposal bug workaround

### DIFF
--- a/EntityFramework.DbContextManagement/EntityFramework.DbContextManagement.csproj
+++ b/EntityFramework.DbContextManagement/EntityFramework.DbContextManagement.csproj
@@ -26,6 +26,7 @@ Release notes:
 - Added static DbContextScope&lt;TDbContext&gt;.HasDbContext, to match the feature set of IDbContextAccessor.
 - Retries now ensure that the connection is closed before retrying, to avoid the risk of leaking session state. (As with EF's DbContext disposal in general, this relies on the database provider's connection reset.)
 - Scoped execution now protects against dangerous "failure on commit" retries even on manual commits (rather than just on IExecutionScope's implicit commit).
+- Worked around an EF bug where the DbContext obscures a real exception (e.g. incorrect entity mapping) by throwing an ObjectDisposedException, even though DbContext._disposed=false.
 - MockDbContextProvider: Fixed a bug where nested scopes would not work as expected.
 - MockDbContextProvider: Fixed a bug where soft attempts to roll back a transaction when there was none could cause an unintended TransactionAbortedException.
 


### PR DESCRIPTION
Worked around an EF bug where the DbContext obscures a real exception (e.g. incorrect entity mapping) by throwing an ObjectDisposedException, even though DbContext._disposed=false.